### PR TITLE
installer: Add support for insecure_installation

### DIFF
--- a/photon_installer/isoInstaller.py
+++ b/photon_installer/isoInstaller.py
@@ -29,6 +29,7 @@ class IsoInstaller(object):
         # if not provided - use /RPMS path from photon_media,
         # exit otherwise.
         repo_path = options.repo_path
+        self.insecure_installation = None
 
         with open('/proc/cmdline', 'r') as f:
             kernel_params = shlex.split(f.read().replace('\n', ''))
@@ -42,6 +43,8 @@ class IsoInstaller(object):
                     repo_path = arg[len("repo="):]
             elif arg.startswith("photon.media="):
                 photon_media = arg[len("photon.media="):]
+            elif arg.startswith("insecure_installation="):
+                self.insecure_installation = bool(int(arg[len("insecure_installation="):]))
 
         if photon_media:
             self.mount_media(photon_media)
@@ -54,7 +57,13 @@ class IsoInstaller(object):
                 return
 
         if ks_path:
-            install_config=self._load_ks_config(ks_path)
+            install_config = self._load_ks_config(ks_path)
+
+        # insecure_installation flag added through commandline overrides that of ks_config
+        if self.insecure_installation:
+            if not install_config:
+                install_config = {}
+            install_config['insecure_installation'] = self.insecure_installation
 
         if options.ui_config_file:
             ui_config = (JsonWrapper(options.ui_config_file)).read()
@@ -77,7 +86,12 @@ class IsoInstaller(object):
 
     def _load_ks_config(self, path):
         """kick start configuration"""
-        if path.startswith("http://"):
+
+        if path.startswith("http://") and not self.insecure_installation:
+            raise Exception("Refusing to download kick start configuration from non-https URLs. \
+                            \nPass insecure_installation=1 as a parameter when giving http url in ks.")
+
+        if path.startswith("https://") or path.startswith("http://"):
             # Do 5 trials to get the kick start
             # TODO: make sure the installer run after network is up
             ks_file_error = "Failed to get the kickstart file at {0}".format(path)
@@ -85,16 +99,16 @@ class IsoInstaller(object):
             for _ in range(0, 5):
                 err_msg = ""
                 try:
-                    response = requests.get(path, timeout=3)
-                    if response.ok:
-                        return json.loads(response.text)
-                    err_msg = response.text
+                    if self.insecure_installation:
+                        response = requests.get(path, timeout=3, verify=False)
+                    else:
+                        response = requests.get(path, timeout=3, verify=True)
                 except Exception as e:
                     err_msg = e
+                else:
+                    return json.loads(response.text)
 
-                print(ks_file_error)
-                print("error msg: {0}".format(err_msg))
-                print("retry in a second")
+                print("error msg: {0}  Retry after {1} seconds".format(err_msg, wait))
                 time.sleep(wait)
                 wait = wait * 2
 

--- a/photon_installer/ks_config.txt
+++ b/photon_installer/ks_config.txt
@@ -54,6 +54,13 @@ Kickstart config file is a json format with following possible parameters:
 	Default value: "photon-<randomized string>"
 	Example: { "hostname": "photon-machine" }
 
+"insecure_installation" (optional)
+	Allow untrusted(selfsigned) https in kickstart iso and
+	disable ssl cert verification in repo for rpms installation.
+	Boolean: true or false
+	Default value: false
+	Example: { "insecure_installation": false }
+
 "live" (optional)
 	Should be set to flase if target system will not be run on
 	host machine. When it set to false, installer will not add EFI boot


### PR DESCRIPTION
This patch adds kernel command line argument: 'insecure_installation'
as a flag that user can set to 1 to allow some operations that aren't
normally allowed due to security concerns. This is disabled by default
and it is up to the user to the ensure security when this options is
enabled.

This patch also disables by default download of ks_config file from non-HTTPS
sources.

Following cases can arise:
i) insecure_installation=1 passed as kernel param in cmdline
   insecure_installation key if present in ks_config ignored
   - ks_config and rpms from untrusted sources -> allowed
ii) insecure_installation=0 passed as kernel param in cmdline
    insecure_installation key if present in ks_config ignored
   - ks_config and rpms from untrusted sources -> not allowed
iii) insecure_installation not passed as kernel param in cmdline
     insecure_installation: true passed in ks_config
   - ks_config from http -> not allowed
   - rpms from untrusted sources -> allowed
iv)  insecure_installation not passed as kernel param in cmdline
     insecure_installation: false passed in ks_config
   - ks_config from http -> not allowed
   - rpms from untrusted sources -> not allowed