### PR TITLE
modules: added a new module to regenerate initrd post installation

### DIFF
--- a/photon_installer/modules/m_mkinitrd.py
+++ b/photon_installer/modules/m_mkinitrd.py
@@ -1,0 +1,11 @@
+import os
+import commons
+
+install_phase = commons.POST_INSTALL
+enabled = True
+
+def execute(installer):
+    ''' If we are building cloud-image/ova, we need to generic initrd '''
+    if os.environ.get('REGENERATE_INITRD', '') == 'TRUE':
+        installer.logger.info('--- Regenerating initrd ---')
+        installer.cmd.run_in_chroot(installer.photon_root, 'mkinitrd -q --no-host-only')


### PR DESCRIPTION
This will help to create a generic initrd for cloud and ova images.

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>