### PR TITLE
Add Xen/XCP block device to device detection code to allow install to proceed

### DIFF
--- a/photon_installer/device.py
+++ b/photon_installer/device.py
@@ -17,7 +17,7 @@ class Device(object):
 
     @staticmethod
     def refresh_devices():
-        devices_list = subprocess.check_output(['lsblk', '-d', '-I', '7,8,179,254,259', '-n',
+        devices_list = subprocess.check_output(['lsblk', '-d', '-I', '7,8,179,202,254,259', '-n',
                                                 '--output', 'NAME,SIZE,MODEL'],
                                                stderr=open(os.devnull, 'w'))
         return Device.wrap_devices_from_list(devices_list)
@@ -25,7 +25,7 @@ class Device(object):
     @staticmethod
     def refresh_devices_bytes():
         devices_list = subprocess.check_output(['lsblk', '-d', '--bytes', '-I',
-                                                '7,8,179,254,259', '-n', '--output', 'NAME,SIZE,MODEL'],
+                                                '7,8,179,202,254,259', '-n', '--output', 'NAME,SIZE,MODEL'],
                                                stderr=open(os.devnull, 'w'))
         return Device.wrap_devices_from_list(devices_list)
 


### PR DESCRIPTION
This PR adds "Xen Virtual Block Device" major device number into "device.py" to allow install on XenServer/XCP-ng hypervisor.

This is as per [PR#1037](https://github.com/vmware/photon/pull/1037) in the original Photon OS repo before the installer was separated out into this repo.