### PR TITLE
Multiple repositories support for installer

### DIFF
--- a/photon_installer/installer.py
+++ b/photon_installer/installer.py
@@ -76,6 +76,7 @@ class Installer(object):
         'preinstallscripts',
         'public_key',
         'photon_docker_image',
+        'repos',
         'search_path',
         'setup_grub_script',
         'shadow_password',
@@ -88,12 +89,12 @@ class Installer(object):
     linux_dependencies = ["devel", "drivers", "docs", "oprofile", "dtb"]
 
     def __init__(self, working_directory="/mnt/photon-root",
-                 rpm_path=os.path.dirname(__file__)+"/../stage/RPMS", log_path=os.path.dirname(__file__)+"/../stage/LOGS",
+                 repo_paths="/mnt/media/RPMS", log_path=os.path.dirname(__file__)+"/../stage/LOGS",
                  insecure_installation=False, photon_release_version='4.0'):
         self.exiting = False
         self.interactive = False
         self.install_config = None
-        self.rpm_path = rpm_path
+        self.repo_paths = repo_paths
         self.log_path = log_path
         self.logger = None
         self.cmd = None
@@ -111,7 +112,6 @@ class Installer(object):
 
         self.photon_root = self.working_directory + "/photon-chroot"
         self.tdnf_conf_path = self.working_directory + "/tdnf.conf"
-        self.tdnf_repo_path = self.working_directory + "/photon-local.repo"
 
         self.setup_grub_command = os.path.join(os.path.dirname(__file__), "mk-setup-grub.sh")
 
@@ -296,6 +296,19 @@ class Installer(object):
         # Default Photon docker image
         if 'photon_docker_image' not in install_config:
             install_config['photon_docker_image'] = "photon:latest"
+
+        # if "repos" key not present in install_config or "repos=" provided by user through cmdline prioritize cmdline
+        if "repos" not in install_config or self.repo_paths != "/mnt/media/RPMS" :
+            # override "repos" provided via ks_config
+            install_config["repos"] = []
+            repo_pathslist = self.repo_paths.split(",")
+            for idx,url in enumerate(repo_pathslist):
+                if url.startswith('/'):
+                    url = f"file://{url}"
+                install_config["repos"].append({"name": f"VMware Photon OS Installer-{idx}",
+                                                "baseurl": url,
+                                                "gpgcheck": 0,
+                                                "enabled": 1})
 
     def _check_install_config(self, install_config):
         """
@@ -847,8 +860,8 @@ class Installer(object):
             shutil.rmtree(cache_dir)
         if os.path.exists(self.tdnf_conf_path):
             os.remove(self.tdnf_conf_path)
-        if os.path.exists(self.tdnf_repo_path):
-            os.remove(self.tdnf_repo_path)
+        for repo in glob.glob(self.working_directory + '/photon-local*.repo'):
+            os.remove(repo)
 
     def _setup_grub(self):
         bootmode = self.install_config['bootmode']
@@ -966,18 +979,15 @@ class Installer(object):
         """
         Setup the tdnf repo for installation
         """
-        with open(self.tdnf_repo_path, "w") as repo_file:
-            repo_file.write("[photon-local]\n")
-            repo_file.write("name=VMware Photon OS Installer\n")
-
-            if self.rpm_path.startswith('/'):
-                repo_file.write("baseurl=file://{}\n".format(self.rpm_path))
-            else:
-                repo_file.write("baseurl={}\n".format(self.rpm_path))
-
-            repo_file.write("gpgcheck=0\nenabled=1\n")
+        repos = self.install_config["repos"]
+        for idx,repo in enumerate(repos):
             if self.insecure_installation:
-                repo_file.write("sslverify=0\n")
+                repo["sslverify"] = 0
+            with open(f'{self.working_directory}/photon-local{idx}.repo', "w") as repo_file:
+                repo_file.write(f"[photon-local{idx}]\n")
+                for key in repo.keys():
+                    repo_file.write(f"{key}={repo[key]}\n")
+
         with open(self.tdnf_conf_path, "w") as conf_file:
             conf_file.writelines([
                 "[main]\n",
@@ -1001,11 +1011,10 @@ class Installer(object):
         docker_args = ['docker', 'run', '--rm', '--ulimit',  'nofile=1024:1024']
         docker_args.extend(['-v', f'{self.working_directory}:{self.working_directory}'])
 
-        rpm_path = self.rpm_path
-        if rpm_path.startswith('file://'):
-            rpm_path = rpm_path[7:]
-        if rpm_path.startswith('/'):
-            docker_args.extend(['-v', f'{rpm_path}:{rpm_path}'])
+        for repo in self.install_config["repos"]:
+            if repo["baseurl"].startswith('file://'):
+                 rpm_path = repo["baseurl"][7:]
+                 docker_args.extend(['-v', f'{rpm_path}:{rpm_path}'])
         docker_args.extend([self.install_config["photon_docker_image"], "/bin/sh", "-c", tdnf_cmd])
         self.logger.info(' '.join(docker_args))
         return self.cmd.run(docker_args)

--- a/photon_installer/isoInstaller.py
+++ b/photon_installer/isoInstaller.py
@@ -24,12 +24,12 @@ class IsoInstaller(object):
         self.media_mount_path = None
         photon_media = None
         ks_path = options.install_config_file
-        # Path to RPMS repository: local media or remote URL
-        # If --repo-path= provided - use it,
-        # if not provided - use kernel repo= parameter,
+        # Comma separated paths to RPMS repository: local media or remote URL
+        # If --repo-paths= provided - use it,
+        # if not provided - use kernel repos= parameter,
         # if not provided - use /RPMS path from photon_media,
         # exit otherwise.
-        repo_path = options.repo_path
+        repo_paths = options.repo_paths
         self.insecure_installation = False
         # On Baremetal, time to emulate /dev/cdrom on different
         # servers varies. So, adding a commandline parameter
@@ -43,9 +43,9 @@ class IsoInstaller(object):
             if arg.startswith("ks="):
                 if not ks_path:
                     ks_path = arg[len("ks="):]
-            elif arg.startswith("repo="):
-                if not repo_path:
-                    repo_path = arg[len("repo="):]
+            elif arg.startswith("repos="):
+                if not repo_paths:
+                    repo_paths = arg[len("repos="):]
             elif arg.startswith("photon.media="):
                 photon_media = arg[len("photon.media="):]
             elif arg.startswith("insecure_installation="):
@@ -56,9 +56,9 @@ class IsoInstaller(object):
         if photon_media:
             self.media_mount_path = self.mount_media(photon_media)
 
-        if not repo_path:
+        if not repo_paths:
             if self.media_mount_path:
-                repo_path = self.media_mount_path + "/RPMS"
+                repo_paths = self.media_mount_path + "/RPMS"
             else:
                 print("Please specify RPM repo path.")
                 return
@@ -78,10 +78,9 @@ class IsoInstaller(object):
         #initializing license display text
         ui_config['license_display_title'] = options.license_display_title
 
-
         try:
             # Run installer
-            installer = Installer(rpm_path=repo_path, log_path="/var/log",
+            installer = Installer(repo_paths=repo_paths, log_path="/var/log",
                                 insecure_installation=self.insecure_installation,
                                 photon_release_version=options.photon_release_version)
 
@@ -178,7 +177,8 @@ if __name__ == '__main__':
     parser.add_argument("-c", "--config", dest="install_config_file")
     parser.add_argument("-u", "--ui-config", dest="ui_config_file")
     parser.add_argument("-j", "--json-file", dest="options_file", default="input.json")
-    parser.add_argument("-r", "--repo-path", dest="repo_path")
+    # Comma separated paths to RPMS
+    parser.add_argument("-r", "--repo-paths", dest="repo_paths")
     options = parser.parse_args()
 
     IsoInstaller(options)

--- a/photon_installer/ks_config.txt
+++ b/photon_installer/ks_config.txt
@@ -410,4 +410,25 @@ Kickstart config file is a json format with following possible parameters:
         Default value: "photon:latest"
 	Example: { "photon_docker_image": "photon:3.0" }
 
+"repos" (optional)
+	Specify one or more RPM repos to install the rpms from
+	Default value: [
+				{
+				"name": "VMware Photon OS Installer-0",
+				"baseurl": "/mnt/media/RPMS",
+				"gpgcheck": 0,
+				"enabled": 1
+				}
+			]
+	Example: [
+			{
+			"name": "photon release",
+			"baseurl": "https://packages.vmware.com/photon/4.0/photon_release_4.0_x86_64/",
+			"enabled": 1 },
+			{
+			"name": "photon updates",
+			"baseurl": "https://packages.vmware.com/photon/4.0/photon_updates_4.0_x86_64/",
+			"enabled": 1 }
+		]
+
 For reference, look at "sample_ks.cfg" file

--- a/photon_installer/main.py
+++ b/photon_installer/main.py
@@ -11,10 +11,10 @@ def main():
     parser.add_argument("-i", "--image-type", dest="image_type")
     parser.add_argument("-c", "--install-config", dest="install_config_file")
     parser.add_argument("-u", "--ui-config", dest="ui_config_file")
-    parser.add_argument("-r", "--repo-path", dest="repo_path")
+    # comma separated paths to rpms
+    parser.add_argument("-r", "--repo-paths", dest="repo_paths")
     parser.add_argument("-o", "--options-file", dest="options_file")
     parser.add_argument("-w", "--working-directory", dest="working_directory")
-    parser.add_argument("-p", "--rpm-path", dest="rpm_path")
     parser.add_argument("-l", "--log-path", dest="log_path")
     parser.add_argument("-e", "--eula-file", dest="eula_file_path", default=None)
     parser.add_argument("-t", "--license-title", dest="license_display_title", default=None)
@@ -36,7 +36,7 @@ def main():
         else:
             raise Exception('install config file not provided')
 
-        installer = Installer(working_directory=options.working_directory, rpm_path=options.rpm_path,
+        installer = Installer(working_directory=options.working_directory, repo_paths=options.repo_paths,
                             log_path=options.log_path, photon_release_version=options.photon_release_version)
         installer.configure(install_config)
         installer.execute()


### PR DESCRIPTION
Currently installer generates one repo i.e photon-local.repo which point to /mnt/media/RPMS for iso or stage/RPMS or repo path provided by user.

With added functionality, multiple repo configs are taken as input via "repos" key as list of dictionaries in the install_config/ks_config file via json.

Image Creation(ova/cloud-images):
 - by default "stage/RPMS" path is taken
 - user can specify "repos" with "name","baseurl" etc in config_<img>.json 

Iso Creation:
 - default "/mnt/media/RPMS" path is taken
 - comma seperated repo urls can be specified via kernel cmdline "repos=url1,url2"
 - user can specify "repos" with "name","baseurl" etc in ks_config file