### PR TITLE
sample_ks: Fixing boot partition size in case of btrfs.

### DIFF
--- a/sample_ks/sample_ks_btrfs_xfs.cfg
+++ b/sample_ks/sample_ks_btrfs_xfs.cfg
@@ -28,7 +28,7 @@
         },
         {
             "mountpoint": "/boot",
-            "size": 128,
+            "size": 256,
             "filesystem": "btrfs",
             "btrfs": {
                 "label": "boot"


### PR DESCRIPTION
Issue: In case of btrfs partition, it reserve some space as 'space_cache' due to which grub2-install command fails to install i386-pc files because no space left.

Fix: Increased the size of boot partition.