### PR TITLE
Fix Dockerfile COPY syntax for multi-file copy

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,8 +79,9 @@ COPY \
      create-ostree \
      create-cherrypicks-repo \
      create-pkg \
-     poi-pkglist yjson \
-     /usr/bin
+     poi-pkglist \
+     yjson \
+     /usr/bin/
 
 VOLUME /repo /workdir
 


### PR DESCRIPTION
## Problem

While building the `photon/installer` Docker image, the build fails at step 23 with the error:

```
COPY create-image create-ova create-repo create-azure create-ostree create-cherrypicks-repo create-pkg poi-pkglist yjson /usr/bin
When using COPY with more than one source file, the destination must be a directory and end with a /
```

## Root Cause

The `docker/Dockerfile` has two issues in the COPY instruction:

1. `poi-pkglist yjson` on one line is interpreted as a single argument with a space, but these are two separate files that should each be on their own line
2. The destination `/usr/bin` is missing a trailing slash, which is required by Docker when copying multiple files

## Fix

- Split `poi-pkglist yjson` into two separate lines (`poi-pkglist \` and `yjson \`)
- Add trailing slash to destination: `/usr/bin/`

## Testing

After applying this fix, the Docker image builds successfully and the Photon OS ISO can be generated.

## Reference

- Docker COPY documentation: https://docs.docker.com/engine/reference/builder/#copy