### PR TITLE
Fix AttributeError when progress_bar not initialized in UI mode

### DIFF
--- a/photon_installer/installer.py
+++ b/photon_installer/installer.py
@@ -133,6 +133,8 @@ class Installer(object):
         self.ab_present = False
         self.mounts = []
         self.cwd = os.getcwd()
+        self.progress_bar = None  # Initialize to prevent AttributeError
+        self.window = None        # Initialize to prevent AttributeError
 
         # some keys can have arch specific variations
         for key in ['packages', 'linux_flavor']:
@@ -831,8 +833,9 @@ class Installer(object):
         del frame1
         if not self.exiting and self.install_config:
             self.exiting = True
-            if self.install_config['ui']:
+            if self.install_config['ui'] and self.progress_bar is not None:
                 self.progress_bar.hide()
+            if self.install_config['ui'] and self.window is not None:
                 self.window.addstr(0, 0, 'Oops, Installer got interrupted.\n\n' +
                                    'Press any key to get to the bash...')
                 self.window.content_window().getch()


### PR DESCRIPTION
## Problem

The installer crashes with `AttributeError: 'Installer' object has no attribute 'progress_bar'` when using kickstart with `ui: true` if an exception occurs before the progress_bar is created.

## Root Cause

1. When `ui: true` in kickstart, `install_config['ui']` is `True`
2. `execute()` method calls `curses.wrapper(self._install)`
3. Inside `_install()`, `self.progress_bar` is created only **after** curses initialization succeeds (around line 763)
4. If any exception occurs before `progress_bar` creation, `exit_gracefully()` is called
5. `exit_gracefully()` checks `if self.install_config['ui']:` and tries to access `self.progress_bar.hide()`
6. This fails with `AttributeError` because `progress_bar` was never created as an instance attribute

## Fix (Surgical - only modifies exit_gracefully)

1. Initialize `self.progress_bar = None` in `__init__()`
2. Initialize `self.window = None` in `__init__()`
3. In `exit_gracefully()`, check `progress_bar is not None` before calling `hide()`
4. In `exit_gracefully()`, check `window is not None` before calling `addstr()`

This is a **minimal fix** that only affects error handling. The normal installer flow is unchanged - `progress_bar` gets created in `_install()` before any other code tries to use it.

## Changes

- `photon_installer/installer.py`: 4 insertions, 1 deletion

## Why this approach?

The previous version of this PR changed ALL occurrences of `if self.install_config['ui']:` which broke the installer because:
- The `execute()` method check decides whether to use curses (must not change)
- The `_install()` method check creates progress_bar (must not change)
- Other methods run AFTER progress_bar is created (no fix needed)

This surgical fix only modifies `exit_gracefully()` which is the only place that can be called before progress_bar exists.