### PR TITLE
installer: add btrfs-progs to target when btrfs filesystem is selected

### DIFF
--- a/photon_installer/installer.py
+++ b/photon_installer/installer.py
@@ -2312,6 +2312,10 @@ password_pbkdf2 {grub_user} {grub_password_hash}
             # add lvm2 package to install list
             self._add_packages_to_install('lvm2')
 
+        # add btrfs-progs if any partition uses btrfs
+        if any(p.get('filesystem') == 'btrfs' for p in partitions):
+            self._add_packages_to_install('btrfs-progs')
+
         # Create partitions_data (needed for mk-setup-grub.sh)
         for partition in partitions:
             if 'mountpoint' in partition and not partition.get('shadow', False):


### PR DESCRIPTION
## Problem

When installing Photon OS with btrfs as the root filesystem, the system fails to boot because dracut does not include the btrfs kernel module in the initramfs. This happens because `btrfs-progs` is not installed in the target system during installation.

## Root Cause

The installer conditionally adds filesystem tools for LVM (`lvm2`) but has no equivalent logic for btrfs. Without `btrfs-progs` in the target, dracut cannot detect the btrfs root and omits the btrfs module from the initramfs, resulting in a kernel panic at boot:

```
VFS: Cannot open root device ... or unknown-block(0,0): error -6
```

## Fix

Add `btrfs-progs` to the package install list when any partition uses the btrfs filesystem, following the same pattern as the existing `lvm2` conditional install:

```python
# add btrfs-progs if any partition uses btrfs
if any(p.get('filesystem') == 'btrfs' for p in partitions):
    self._add_packages_to_install('btrfs-progs')
```

This is a no-op for ext4/xfs installs since the condition only triggers when btrfs is actually selected.

## Applicable Versions

The bug affects **all versions that support btrfs filesystem selection** (v2.1 through v2.8 and master). Btrfs partition support was introduced in [commit `8a3c0c0`](https://github.com/vmware/photon-os-installer/commit/8a3c0c09b31a50d56724eef3ce617ea20c0f24c9) (June 2022, v2.1+), but `btrfs-progs` was never added to the target package list. The fix inserts the conditional install next to the existing `lvm2` pattern, which is present in all versions since v2.1.

| photon-os-installer version | btrfs support | Bug present |
|-----------------------------|--------------|-------------|
| v2.0 | No | N/A (no btrfs) |
| v2.1 -- v2.8 | Yes | **Yes** |
| master (HEAD) | Yes | **Yes** |

The corresponding Photon OS 5.0 packaging changes (spec bump, updated source tarball sha512) are tracked in a separate PR to [vmware/photon](https://github.com/vmware/photon).

## Testing

Verified with Photon OS 5.0 btrfs + STIG hardening install on VMware Workstation (UEFI, TPM 2.0, VM encryption). System boots successfully with btrfs root filesystem. Also verified ext4 installs are unaffected.