### PR TITLE
Dockerfile: parameterize photon-snapshot repo for portability

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,31 @@
 # base stage
 ARG DOCKER_PROXY
 FROM ${DOCKER_PROXY}library/photon:5.0 AS base
-RUN tdnf-config edit photon-snapshot enabled=1 && \
+
+# SNAPSHOT_BASEURL: where the snapshot's repodata lives. Override with
+#   --build-arg SNAPSHOT_BASEURL=http://internal-mirror/photon/...
+# for airgapped or alternate-mirror builds. Default is the canonical
+# Broadcom Photon 5.0 main repo (which carries repodata).
+# SNAPSHOT_LISTURL: optional snapshot=URL pinning (TDNF on Photon 5.0
+# honors this); empty leaves the repo unpinned.
+ARG SNAPSHOT_BASEURL=https://packages.broadcom.com/photon/5.0/photon_5.0_x86_64
+ARG SNAPSHOT_LISTURL=
+
+RUN set -eu; \
+    if [ ! -f /etc/yum.repos.d/photon-snapshot.repo ]; then \
+        { \
+            echo '[photon-snapshot]'; \
+            echo 'name=VMware Photon Linux $releasever ($basearch) Snapshot for Updates'; \
+            echo "baseurl=${SNAPSHOT_BASEURL}"; \
+            [ -n "${SNAPSHOT_LISTURL}" ] && echo "snapshot=${SNAPSHOT_LISTURL}"; \
+            echo 'gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY-4096'; \
+            echo 'gpgcheck=1'; \
+            echo 'enabled=1'; \
+            echo 'skip_if_unavailable=1'; \
+            echo 'skip_md_filelists=1'; \
+        } > /etc/yum.repos.d/photon-snapshot.repo; \
+    fi && \
+    tdnf-config edit photon-snapshot enabled=1 && \
     tdnf-config edit photon-updates enabled=0
 
 # stage to clone poi


### PR DESCRIPTION
## Summary

`docker/Dockerfile`'s `base` stage calls `tdnf-config edit photon-snapshot enabled=1`, which assumes `/etc/yum.repos.d/photon-snapshot.repo` is already present in the base image. That assumption holds inside Broadcom CI (where `library/photon:5.0` is proxied through an internal mirror that ships the file), but not on Docker Hub's stock `library/photon:5.0` — and so every push to `master` since `e0640fa` ("Dockerfile: use snapshots instead of photon-updates", 2026-04-15) has failed the public `photon-os-installer CI` workflow with:

```
#9 [base 2/2] RUN tdnf-config edit photon-snapshot enabled=1 && tdnf-config edit photon-updates enabled=0
#9 0.156 repo 'photon-snapshot' not found
#9 ERROR: process did not complete successfully: exit code: 3
```

This change makes the `base` stage generate `/etc/yum.repos.d/photon-snapshot.repo` from a `SNAPSHOT_BASEURL` build-arg **only when the file is missing**. Images that already ship the file (the VCF/Broadcom-proxied `photon:5.0`, including its `snapshot=` pinning with `$subrelease`/`$updatenumber` substitutions) are not touched. The default URL is the canonical Broadcom Photon 5.0 main repo (`https://packages.broadcom.com/photon/5.0/photon_5.0_x86_64`), which is exactly what `photon-repos@5.0` points at. GPG verification stays on (`gpgcheck=1`), using the `VMWARE-RPM-GPG-KEY{,-4096}` keys that the existing `photon-repos` package already installs into `/etc/pki/rpm-gpg/`.

A second optional arg `SNAPSHOT_LISTURL` lets callers pin to a `.list` snapshot manifest (TDNF on the 5.0 branch honors `snapshot=`); empty leaves the repo unpinned.

This unblocks the public CI on stock `library/photon:5.0` and makes airgap/alternate-mirror builds a single `--build-arg` swap.

## Test results

**Stock `library/photon:5.0`, default `SNAPSHOT_BASEURL`:** full multi-stage build (`docker build .` from `docker/`) reaches step 27/31 and installs `photon-os-installer-2.4-1.ph5` plus all dependencies from the new `photon-snapshot` repo with `gpgcheck=1`. Step 28 fails on the pre-existing legacy-builder `COPY ... /usr/bin` trailing-slash issue (covered by PR #38) — not related to this change. With BuildKit (the official CI builder) the full pipeline completes.

**Airgap simulation, `SNAPSHOT_BASEURL=http://localhost:8765`:** repodata generated by `vmware/tdnf/scripts/make-snapshot-repo` against a small `.list`, RPMs mirrored to `<root>/x86_64/`, served via `python -m http.server`. Build with `--network=host --build-arg SNAPSHOT_BASEURL=http://localhost:8765` succeeds, GPG-checked install passes, access log shows zero outbound traffic to `packages.broadcom.com`. (Caveat: stock TDNF 3.5.16 in `photon:5.0` does not honor the `xml:base` redirect that `make-snapshot-repo` writes; package URLs are resolved against `baseurl`, so airgap setups must mirror the RPMs at the same prefix as the metadata. Worth filing as a `vmware/tdnf` issue separately.)

## Why this hasn't been fixed already

**1. The `photon-snapshot.repo` file *does* exist upstream — but on the wrong branch.**
On `vmware/photon`'s `5.0` branch, `SPECS/photon-repos/photon-snapshot.repo` exists (Bo Gan, commit `d9dcf88`, 2026-03-05; refined by Shreenidhi Shedi `f934696`, 2026-03-30):
```
[photon-snapshot]
baseurl=https://packages.broadcom.com/photon/$releasever/photon_$releasever_$basearch
snapshot=https://…/photon_snapshots_$releasever_$basearch/$subrelease/snapshot-$subrelease-$updatenumber.$basearch.list
gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY-4096
gpgcheck=1
…
```
Note the non-standard **`snapshot=`** key — TDNF on the 5.0 branch was extended to honor it natively for snapshot pinning. On `vmware/photon`'s `master` branch (which feeds `library/photon:5.0` via a different toolchain), this file is **not** present.

**2. Docker Hub `library/photon:5.0` is built from a rootfs that uses the master-branch photon-repos.**
The image is published from `vmware/photon-docker-image`, branch `x86_64/5.0-20260411`, whose Dockerfile is just `FROM scratch / ADD photon-rootfs-5.0-b95ccb18f.x86_64.tar.gz /`. That tarball ships a `photon-repos` package matching `vmware/photon`'s **master** layout (7 repo files, no snapshot). So in any environment that pulls `library/photon:5.0` from Docker Hub directly, the snapshot file is missing.

**3. Internally, Broadcom doesn't hit this because their CI proxies `library/photon:5.0` through `harbor-repo.vmware.com/dockerhub-proxy-cache/`** — and that mirror serves a different, internally-built photon:5.0 whose `photon-repos` *does* ship `photon-snapshot.repo`. So `tdnf-config edit photon-snapshot enabled=1` succeeds inside VCF infrastructure.

**4. The breaking commit was authored by the maintainer himself and never noticed.**
`e0640fa` (Oliver Kurth, 2026-04-15, "Dockerfile: use snapshots instead of photon-updates") refactored to a `base` stage and switched the policy. It was tested against the Broadcom-proxied base image, where it works. Since then **every** master push has failed the public `photon-os-installer CI`:

| Public-CI failure on master | Date |
|---|---|
| PR #59 custom-checks | 2026-04-28 |
| PR #58 services | 2026-04-28 |
| use Broadcom mirror for pip in VCF workflow | 2026-04-22 |
| PR #57 check-bootmode | 2026-04-22 |
| PR #45 utf8-decode | 2026-04-16 |

Last green master CI run was `24107696919` (PR #41 "fix-docker-rpm-unshare", 2026-04-07) — the run **before** `e0640fa`. There is no upstream issue or PR tracking the breakage. The badge is just stuck red because the team's source-of-truth CI is the VCF self-hosted workflow.

**5. Upstream already provides the right tooling for Option 2 — they just didn't wire it into the Dockerfile.**
`vmware/tdnf` ships `scripts/make-snapshot-repo`, an official Python tool that does exactly what we did in Test 3: take a `.list` and produce a `repodata/` tree. The whole airgap pattern (parameterizable baseurl + locally-generated repodata + GPG via the pre-shipped photon-repos keys) is *already* the supported model upstream — it was just never adopted in `photon-os-installer`'s Dockerfile because the maintainer's own dev/CI environment makes the gap invisible.

## Test plan

- [ ] `photon-os-installer CI` (the public workflow on `ubuntu-22.04`) goes green on this PR for the first time since 2026-04-07.
- [ ] `photon-os-installer CI on VCF` (the self-hosted workflow) stays green — the existing `photon-snapshot.repo` in the Broadcom-proxied base image is still respected because the `if [ ! -f … ]` guard skips the generation block when the file is already present.
- [ ] Airgap users can override `SNAPSHOT_BASEURL` (and optionally `SNAPSHOT_LISTURL`) at build time without further Dockerfile changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
