### PR TITLE
isoInstaller: fix interactive (no-kickstart) ISO install

### DIFF
--- a/photon_installer/isoInstaller.py
+++ b/photon_installer/isoInstaller.py
@@ -79,8 +79,12 @@ class IsoInstaller(object):
         else:
             install_config = self._load_ks_config_platform(verify=not insecure_installation)
 
-        # 'live' should be True for iso installs
-        if 'live' not in install_config:
+        # 'live' should be True for iso installs. Only stamp it on an actual
+        # (non-empty) kickstart config. For an interactive install the config
+        # is empty here and must stay falsy, otherwise installer.configure()
+        # ('if not install_config and ui_config') skips the UI configurator
+        # and _check_install_config() fails with "No disk configured".
+        if install_config and 'live' not in install_config:
             install_config['live'] = True
 
         if insecure_installation and install_config is not None:
@@ -164,7 +168,10 @@ class IsoInstaller(object):
         if CommandUtils.is_vmware_virtualization():
             return self._load_ks_config_vmware(verify=verify)
         else:
-            return None
+            # No platform-provided kickstart: fall back to an interactive
+            # install with an empty config. Returning None here makes the
+            # caller crash at "if 'live' not in install_config".
+            return {}
 
     def _load_ks_config_vmware(self, verify=True):
         try:
@@ -191,6 +198,10 @@ class IsoInstaller(object):
             print(
                 f"Failed to run vmtoolsd, do you have open-vm-tools installed? Error: {e}"
             )
+        # No guestinfo kickstart (data/url both absent) or vmtoolsd missing:
+        # fall back to an interactive install with an empty config instead of
+        # returning None, which would crash at "if 'live' not in install_config".
+        return {}
 
     def mount_media(self, photon_media, mount_path=Defaults.MOUNT_PATH):
         """Mount the external media"""


### PR DESCRIPTION
## Summary
Booting a Photon ISO **interactively** (no `ks=` boot parameter, no `-c` config, and no VMware `guestinfo.kickstart.*`) is broken by two coupled regressions:

1. `_load_ks_config_platform()` / `_load_ks_config_vmware()` return `None` when no platform-provided kickstart exists. `IsoInstaller.__init__` then dereferences it at `if 'live' not in install_config`, raising:
   `TypeError: argument of type 'NoneType' is not a container or iterable`.
2. The `'live'` block unconditionally sets `install_config['live'] = True`, making the otherwise-empty interactive config truthy. `installer.configure()` runs the curses UI configurator only when `not install_config`, so the UI is skipped and `_check_install_config()` fails with `No disk configured`.

## Fix
- Platform loaders return an empty `{}` config instead of `None`.
- The `'live'` flag is stamped only on a non-empty (kickstart) config, so the interactive config stays falsy and the UI configurator runs (`'live'` then defaults via `_add_defaults()`).

Regression introduced by 9fc8733 on top of 0a72c3a. Verified end-to-end with an interactive install on a VMware VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)