### PR TITLE
tdnf: capture install output so it does not overlay the curses UI

### DIFF
--- a/photon_installer/tdnf.py
+++ b/photon_installer/tdnf.py
@@ -177,7 +177,19 @@ class Tdnf:
 
             return retval, out_json
         else:
-            return subprocess.check_call(args)
+            # Capture output and route it to the log instead of inheriting the
+            # parent's stdout/stderr. During a UI (curses) install the latter
+            # overlays the progress bar with tdnf/rpm messages such as file
+            # paths (e.g. /etc/os-release).
+            process = subprocess.Popen(
+                args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            )
+            for line in process.stdout:
+                self.logger.info(line.decode('utf-8', errors='replace').rstrip())
+            retval = process.wait()
+            if retval != 0:
+                raise subprocess.CalledProcessError(retval, args)
+            return retval
 
     def run(self, args=None, do_json=True):
         # Fix mutable default arguments issue


### PR DESCRIPTION
## Summary
`Tdnf.execute(do_json=False)` uses `subprocess.check_call(args)`, which inherits the installer's stdout/stderr. During a curses (UI) install, tdnf/rpm output — including file paths such as `/etc/os-release` — is printed directly to the terminal and overlays the installer progress bar.

## Fix
Capture the subprocess output and route it to the installer log instead, preserving the previous return value and failure (`CalledProcessError`) behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)